### PR TITLE
Small change to trigger formatting action

### DIFF
--- a/conversion_obj_step.py
+++ b/conversion_obj_step.py
@@ -14,13 +14,17 @@ file = open("./ORIGINALVOXEL-3.obj", "rb")
 content = file.read()
 file.close()
 
-fc: FileConversionWithOutput = create_file_conversion_with_base64_helper.sync(client=client, body=content, src_format=FileConversionSourceFormat.OBJ, output_format=FileConversionOutputFormat.STEP)
+fc: FileConversionWithOutput = create_file_conversion_with_base64_helper.sync(
+    client=client,
+    body=content,
+    src_format=FileConversionSourceFormat.OBJ,
+    output_format=FileConversionOutputFormat.STEP)
 
 print(f"File conversion id: {fc.id}")
 print(f"File conversion status: {fc.status}")
 
 output_file_path = "./output.step"
 print(f"Saving output to {output_file_path}")
-output_file = open(output_file_path ,"wb")
+output_file = open(output_file_path, "wb")
 output_file.write(fc.output)
 output_file.close()

--- a/conversion_obj_stl.py
+++ b/conversion_obj_stl.py
@@ -14,14 +14,17 @@ file = open("./ORIGINALVOXEL-3.obj", "rb")
 content = file.read()
 file.close()
 
-fc: FileConversionWithOutput = create_file_conversion_with_base64_helper.sync(client=client, body=content, src_format=FileConversionSourceFormat.OBJ, output_format=FileConversionOutputFormat.STL)
+fc: FileConversionWithOutput = create_file_conversion_with_base64_helper.sync(
+    client=client,
+    body=content,
+    src_format=FileConversionSourceFormat.OBJ,
+    output_format=FileConversionOutputFormat.STL)
 
 print(f"File conversion id: {fc.id}")
 print(f"File conversion status: {fc.status}")
 
 output_file_path = "./output.stl"
 print(f"Saving output to {output_file_path}")
-output_file = open(output_file_path ,"wb")
+output_file = open(output_file_path, "wb")
 output_file.write(fc.output)
 output_file.close()
-


### PR DESCRIPTION
Python formatting was setup in b054afaf0200e9c656f7158bf3ecaeeba9d698a1
appears to be working.

PEP8 already has a default of 80chars, so no special args needed for that.

Related to #4 