### PR TITLE
Add issue to project action

### DIFF
--- a/.github/workflows/add-issues-to-project.yml
+++ b/.github/workflows/add-issues-to-project.yml
@@ -1,0 +1,13 @@
+name: "Add issues to 'All Tasks' Project"
+
+on:
+  issues:
+    types: [opened]
+jobs:
+  createCard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: KittyCAD/add-issues-to-project@v0.0.1
+        with:
+          token: ${{ secrets.GLOBAL_PAT }}
+          issue-node: ${{ github.event.issue.node_id }}"


### PR DESCRIPTION
Each repo will need to have this action added. I thought I could add it as a workflow template and that's why I added the `.github` repo, but we need the org to be on an enterprise or GitHub One plan. I don't think it's a big problem since it's minimal is the action in [KittyCAD/add-issues-to-project](https://github.com/KittyCAD/add-issues-to-project) is mostly the source of truth. (I'll remove the .github repo)

KittyCAD/add-issues-to-project is a public repo, because actions have to be. There's no secret source in there though of course.