### PR TITLE
update action tests after python sdk was updated

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -5,10 +5,12 @@ on:
     paths:
       - '**.py'
       - .github/workflows/build-test.yml
+      - requirements.txt
   pull_request:
     paths:
       - '**.py'
       - .github/workflows/build-test.yml
+      - requirements.txt
   workflow_dispatch:
     inputs:
 jobs:

--- a/tutorials/conversion_obj_step/conversion_obj_step.py
+++ b/tutorials/conversion_obj_step/conversion_obj_step.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 from kittycad.client import ClientFromEnv
-from kittycad.models import FileConversionWithOutput, FileConversionSourceFormat, FileConversionOutputFormat
+from kittycad.models import file_output_format, file_source_format, file_conversion
 from kittycad.api.file import create_file_conversion_with_base64_helper
 import json
 
@@ -14,11 +14,11 @@ file = open("./ORIGINALVOXEL-3.obj", "rb")
 content = file.read()
 file.close()
 
-fc: FileConversionWithOutput = create_file_conversion_with_base64_helper.sync(
+fc: file_conversion.FileConversion = create_file_conversion_with_base64_helper.sync(
     client=client,
     body=content,
-    src_format=FileConversionSourceFormat.OBJ,
-    output_format=FileConversionOutputFormat.STEP)
+    src_format=file_source_format.FileSourceFormat.OBJ,
+    output_format=file_output_format.FileOutputFormat.STEP)
 
 print(f"File conversion id: {fc.id}")
 print(f"File conversion status: {fc.status}")

--- a/tutorials/conversion_obj_stl/conversion_obj_stl.py
+++ b/tutorials/conversion_obj_stl/conversion_obj_stl.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 from kittycad.client import ClientFromEnv
-from kittycad.models import FileConversionWithOutput, FileConversionSourceFormat, FileConversionOutputFormat
+from kittycad.models import file_output_format, file_source_format, file_conversion
 from kittycad.api.file import create_file_conversion_with_base64_helper
 import json
 
@@ -14,11 +14,11 @@ file = open("./ORIGINALVOXEL-3.obj", "rb")
 content = file.read()
 file.close()
 
-fc: FileConversionWithOutput = create_file_conversion_with_base64_helper.sync(
+fc: file_conversion.FileConversion = create_file_conversion_with_base64_helper.sync(
     client=client,
     body=content,
-    src_format=FileConversionSourceFormat.OBJ,
-    output_format=FileConversionOutputFormat.STL)
+    src_format=file_source_format.FileSourceFormat.OBJ,
+    output_format=file_output_format.FileOutputFormat.STL)
 
 print(f"File conversion id: {fc.id}")
 print(f"File conversion status: {fc.status}")


### PR DESCRIPTION
Despite the branch name this issue relates to #28 which broke the python tutorials.

The test are not fired with changes to `requirements.txt` so the merger of #28 did not realise that it caused issues. The workflow has been update so the tests do run and the python scripts have been fixed as well.
