### PR TITLE
Create conversion_obj_step

### DIFF
--- a/tutorials/conversion_obj_step/conversion_obj_step
+++ b/tutorials/conversion_obj_step/conversion_obj_step
@@ -1,0 +1,12 @@
+{
+    "name": "title",
+    "outputs": [],
+    "files": [
+        {
+            "extension": "go"
+        },
+        {
+            "extension": "py"
+        }
+    ]
+}


### PR DESCRIPTION
As apart of https://github.com/KittyCAD/website/issues/800 all tutorials need a metadata json file, even if it's not a litterbox tutorial