### PR TITLE
Add SEO metadata to all samples

### DIFF
--- a/samples/convert_file/convert_file.json
+++ b/samples/convert_file/convert_file.json
@@ -3,6 +3,10 @@
     "tags": [
       "convert"
     ],
+    "seo": {
+      "title": "Convert File Sample",
+      "description": "A live editable sample of how to convert a file from one format to another using the KittyCAD API."
+    },
     "outputs": [
       {
           "path": "samples/convert_file/output.stl",

--- a/samples/file_center_of_mass/file_center_of_mass.json
+++ b/samples/file_center_of_mass/file_center_of_mass.json
@@ -3,6 +3,10 @@
     "tags": [
       "metadata"
     ],
+    "seo": {
+      "title": "File Center of Mass Sample",
+      "description": "A live editable sample of how to get the center of mass of a 3D model using the KittyCAD API."
+    },
     "outputs": [
       {
           "path": "samples/file_center_of_mass/output.json",

--- a/samples/file_density/file_density.json
+++ b/samples/file_density/file_density.json
@@ -3,6 +3,10 @@
     "tags": [
       "metadata"
     ],
+    "seo": {
+      "title": "File Density Sample",
+      "description": "A live editable sample of how to get the density of a 3D model using the KittyCAD API."
+    },
     "outputs": [
       {
           "path": "samples/file_density/output.json",

--- a/samples/file_mass/file_mass.json
+++ b/samples/file_mass/file_mass.json
@@ -3,6 +3,10 @@
     "tags": [
       "metadata"
     ],
+    "seo": {
+      "title": "File Mass Sample",
+      "description": "A live editable sample of how to get the mass of a 3D model using the KittyCAD API."
+    },
     "outputs": [
       {
           "path": "samples/file_mass/output.json",

--- a/samples/file_surface_area/file_surface_area.json
+++ b/samples/file_surface_area/file_surface_area.json
@@ -3,6 +3,10 @@
     "tags": [
       "metadata"
     ],
+    "seo": {
+      "title": "File Surface Area Sample",
+      "description": "A live editable sample of how to get the surface area of a 3D model using the KittyCAD API."
+    },
     "outputs": [
       {
           "path": "samples/file_surface_area/output.json",

--- a/samples/file_volume/file_volume.json
+++ b/samples/file_volume/file_volume.json
@@ -3,6 +3,10 @@
     "tags": [
       "metadata"
     ],
+    "seo": {
+      "title": "File Volume Sample",
+      "description": "A live editable sample of how to get the volume of a 3D model using the KittyCAD API."
+    },
     "outputs": [
       {
           "path": "samples/file_volume/output.json",


### PR DESCRIPTION
Blocked by https://github.com/KittyCAD/website/pull/1074

Adds a new `seo` object to the JSON of each of the sample metadata definitions, which will power the SEO of the `/docs/samples` page's SEO.