### PR TITLE
build(deps)!: bump @kittycad/lib to v3, RIP '/import'

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,6 @@
   "author": "KittyCAD",
   "license": "",
   "dependencies": {
-    "@kittycad/lib": "^2.0.39"
+    "@kittycad/lib": "^3.0.0"
   }
 }

--- a/samples/convert_file/convert_file.js
+++ b/samples/convert_file/convert_file.js
@@ -1,5 +1,5 @@
 import fsp from 'fs/promises'
-import { file } from '@kittycad/lib/import'
+import { file } from '@kittycad/lib'
 
 async function main() {
     const body = await fsp.readFile('./ORIGINALVOXEL-3.obj', 'base64')

--- a/samples/file_center_of_mass/file_center_of_mass.js
+++ b/samples/file_center_of_mass/file_center_of_mass.js
@@ -8,13 +8,13 @@ async function main() {
     // LITTERBOX-END-NON-EDITABLE-SECTION
 
     const response = await file.create_file_center_of_mass({
-        material_density: 7,
+        output_unit: 'mm',
         src_format: 'obj',
         body,
     })
     if ('error_code' in response) throw response
     const { center_of_mass } = response
-    console.log(`File center of mass: ${center_of_mass}`)
+    console.log(`File center of mass: ${JSON.stringify(center_of_mass)}`)
     const partInfo = {
         title: 'output.json',
         center_of_mass,

--- a/samples/file_center_of_mass/file_center_of_mass.js
+++ b/samples/file_center_of_mass/file_center_of_mass.js
@@ -1,7 +1,7 @@
 import fsp from 'fs/promises'
 import { exec } from 'child_process'
 import { promisify } from 'util'
-import { file } from '@kittycad/lib/import'
+import { file } from '@kittycad/lib'
 
 async function main() {
     const body = await fsp.readFile('./seesaw.obj', 'base64')

--- a/samples/file_density/file_density.js
+++ b/samples/file_density/file_density.js
@@ -9,6 +9,8 @@ async function main() {
 
     const response = await file.create_file_density({
         material_mass: 123,
+        material_mass_unit: 'g',
+        output_unit: 'kg:m3',
         src_format: 'obj',
         body,
     })

--- a/samples/file_density/file_density.js
+++ b/samples/file_density/file_density.js
@@ -1,7 +1,7 @@
 import fsp from 'fs/promises'
 import { exec } from 'child_process'
 import { promisify } from 'util'
-import { file } from '@kittycad/lib/import'
+import { file } from '@kittycad/lib'
 
 async function main() {
     const body = await fsp.readFile('./ORIGINALVOXEL-3.obj', 'base64')

--- a/samples/file_mass/file_mass.js
+++ b/samples/file_mass/file_mass.js
@@ -1,7 +1,7 @@
 import fsp from 'fs/promises'
 import { exec } from 'child_process'
 import { promisify } from 'util'
-import { file } from '@kittycad/lib/import'
+import { file } from '@kittycad/lib'
 
 async function main() {
     const body = await fsp.readFile('./ORIGINALVOXEL-3.obj', 'base64')

--- a/samples/file_mass/file_mass.js
+++ b/samples/file_mass/file_mass.js
@@ -7,9 +7,12 @@ async function main() {
     const body = await fsp.readFile('./ORIGINALVOXEL-3.obj', 'base64')
     // LITTERBOX-END-NON-EDITABLE-SECTION
 
-    const steelDensityPerCubicMillimeter = 0.00785
+    // Steel density ≈ 7850 kg/m^3
+    const steelDensityKgPerM3 = 7850
     const response = await file.create_file_mass({
-        material_density: steelDensityPerCubicMillimeter,
+        material_density: steelDensityKgPerM3,
+        material_density_unit: 'kg:m3',
+        output_unit: 'g',
         src_format: 'obj',
         body,
     })

--- a/samples/file_surface_area/file_surface_area.js
+++ b/samples/file_surface_area/file_surface_area.js
@@ -1,7 +1,7 @@
 import fsp from 'fs/promises'
 import { exec } from 'child_process'
 import { promisify } from 'util'
-import { file } from '@kittycad/lib/import'
+import { file } from '@kittycad/lib'
 
 async function main() {
     const body = await fsp.readFile('./ORIGINALVOXEL-3.obj', 'base64')

--- a/samples/file_surface_area/file_surface_area.js
+++ b/samples/file_surface_area/file_surface_area.js
@@ -8,6 +8,7 @@ async function main() {
     // LITTERBOX-END-NON-EDITABLE-SECTION
 
     const response = await file.create_file_surface_area({
+        output_unit: 'm2',
         src_format: 'obj',
         body,
     })

--- a/samples/file_volume/file_volume.js
+++ b/samples/file_volume/file_volume.js
@@ -1,7 +1,7 @@
 import fsp from 'fs/promises'
 import { exec } from 'child_process'
 import { promisify } from 'util'
-import { file } from '@kittycad/lib/import'
+import { file } from '@kittycad/lib'
 
 async function main() {
     const body = await fsp.readFile('./ORIGINALVOXEL-3.obj', 'base64')

--- a/samples/file_volume/file_volume.js
+++ b/samples/file_volume/file_volume.js
@@ -8,6 +8,7 @@ async function main() {
     // LITTERBOX-END-NON-EDITABLE-SECTION
 
     const response = await file.create_file_volume({
+        output_unit: 'm3',
         src_format: 'obj',
         body,
     })

--- a/tutorials/beginner_tutorial/convert.js
+++ b/tutorials/beginner_tutorial/convert.js
@@ -1,4 +1,4 @@
-import { file } from '@kittycad/lib/import'
+import { file } from '@kittycad/lib'
 import fsp from 'fs/promises'
 
 async function convertOBJtoSTEP() {

--- a/tutorials/conversion_obj_step/output.step
+++ b/tutorials/conversion_obj_step/output.step
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7a8ed6112d750532ccb6e16e78dc513250b49ba127f93f941b778d05e63ad0ef
+oid sha256:254100e3cd06ab3cb1f1d724fe7a3339737a80e8bc4652ff646fa2f6cf0a282f
 size 546188

--- a/yarn.lock
+++ b/yarn.lock
@@ -27,14 +27,19 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@kittycad/lib@^2.0.39":
-  version "2.0.39"
-  resolved "https://registry.yarnpkg.com/@kittycad/lib/-/lib-2.0.39.tgz#b8d6a6f81a07796052accf136c6058fa9456da68"
-  integrity sha512-axyo5C7BgxtM+nuMe6pBzyGzjKv8dcbnRYP3PSztMP8URpqZvljeWBbbIfkKMULsjtMZuWT288+Z+K2EjXt42g==
+"@kittycad/lib@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@kittycad/lib/-/lib-3.0.0.tgz#2aa3ee52a0877bdd5afe2b4074b0426381543f8a"
+  integrity sha512-r4xq9R3KFVHFj1zsX+bSSPi1c/QwzZQlerSs5bCtfeF/nJSEppDYghAZ1Hquss9vAH5oVi50CwBerG+thz4Zjw==
   dependencies:
+    bson "^6.8.0"
+    cross-fetch "^4.0.0"
     openapi-types "^12.0.0"
     ts-node "^10.9.1"
     tslib "~2.8"
+    ws "^8.17.0"
+  optionalDependencies:
+    win-ca "^3.0.0"
 
 "@tsconfig/node10@^1.0.7":
   version "1.0.9"
@@ -71,25 +76,83 @@ arg@^4.1.0:
   resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
   integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
+bson@^6.8.0:
+  version "6.10.4"
+  resolved "https://registry.yarnpkg.com/bson/-/bson-6.10.4.tgz#d530733bb5bb16fb25c162e01a3344fab332fd2b"
+  integrity sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==
+
 create-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
+
+cross-fetch@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-4.1.0.tgz#8f69355007ee182e47fa692ecbaa37a52e43c3d2"
+  integrity sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==
+  dependencies:
+    node-fetch "^2.7.0"
 
 diff@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
+is-electron@^2.2.0:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/is-electron/-/is-electron-2.2.2.tgz#3778902a2044d76de98036f5dc58089ac4d80bb9"
+  integrity sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==
+
+make-dir@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.3.0.tgz#79c1033b80515bd6d24ec9933e860ca75ee27f0c"
+  integrity sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==
+  dependencies:
+    pify "^3.0.0"
+
 make-error@^1.1.1:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
 
+node-fetch@^2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
+  integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
+  dependencies:
+    whatwg-url "^5.0.0"
+
+node-forge@^1.2.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.1.tgz#be8da2af243b2417d5f646a770663a92b7e9ded3"
+  integrity sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==
+
 openapi-types@^12.0.0:
   version "12.1.0"
   resolved "https://registry.yarnpkg.com/openapi-types/-/openapi-types-12.1.0.tgz#bd01acc937b73c9f6db2ac2031bf0231e21ebff0"
   integrity sha512-XpeCy01X6L5EpP+6Hc3jWN7rMZJ+/k1lwki/kTmWzbVhdPie3jd5O2ZtedEx8Yp58icJ0osVldLMrTB/zslQXA==
+
+pify@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
+  integrity sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==
+
+split@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/split/-/split-1.0.1.tgz#605bd9be303aa59fb35f9229fbea0ddec9ea07d9"
+  integrity sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==
+  dependencies:
+    through "2"
+
+through@2:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
+  integrity sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==
+
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
 
 ts-node@^10.9.1:
   version "10.9.1"
@@ -119,6 +182,34 @@ v8-compile-cache-lib@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
   integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
+
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
+
+win-ca@^3.0.0:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/win-ca/-/win-ca-3.5.1.tgz#2ef37ac24b0a1daa2714b4c5ef258c5242429e00"
+  integrity sha512-RNy9gpBS6cxWHjfbqwBA7odaHyT+YQNhtdpJZwYCFoxB/Dq22oeOZ9YCXMwjhLytKpo7JJMnKdJ/ve7N12zzfQ==
+  dependencies:
+    is-electron "^2.2.0"
+    make-dir "^1.3.0"
+    node-forge "^1.2.1"
+    split "^1.0.1"
+
+ws@^8.17.0:
+  version "8.18.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.3.tgz#b56b88abffde62791c639170400c93dcb0c95472"
+  integrity sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==
 
 yn@3.1.1:
   version "3.1.1"


### PR DESCRIPTION
- Update to ^3.0.0 and switch imports to { file } from '@kittycad/lib'
- Samples and tutorial align with flattened exports, no subpath